### PR TITLE
Added TransactionID to the MessageStatus element

### DIFF
--- a/schemas/AsyncResponse_iepd/api/xml_schema/niem/wantlist.xml
+++ b/schemas/AsyncResponse_iepd/api/xml_schema/niem/wantlist.xml
@@ -22,6 +22,8 @@
   <w:Type w:name="cbrn:MessageStatusType" w:isRequested="false">
     <w:ElementInType w:name="nc:MessageID" w:isReference="false"
       w:minOccurs="1" w:maxOccurs="1"/>
+    <w:ElementInType w:name="nc:TransactionID" w:isReference="false"
+      w:minOccurs="0" w:maxOccurs="1"/>
     <w:ElementInType w:name="cbrn:MessageStatusCode"
       w:isReference="false" w:minOccurs="1" w:maxOccurs="1"/>
     <w:ElementInType w:name="cbrn:MessageContentError"

--- a/schemas/AsyncResponse_iepd/api/xml_schema/niem/xsd/domains/cbrn.xsd
+++ b/schemas/AsyncResponse_iepd/api/xml_schema/niem/xsd/domains/cbrn.xsd
@@ -86,6 +86,7 @@
 			<xs:extension base="cbrn:SystemEventType">
 				<xs:sequence>
 					<xs:element ref="nc:MessageID" minOccurs="1" maxOccurs="1"/>
+					<xs:element ref="nc:TransactionID" minOccurs="0" maxOccurs="1"/>
 					<xs:element ref="cbrn:MessageStatusCode" minOccurs="1" maxOccurs="1"/>
 					<xs:element ref="cbrn:MessageContentError" minOccurs="0" maxOccurs="1"/>
 					<xs:element ref="cbrn:MessageHandlingError" minOccurs="0" maxOccurs="1"/>

--- a/schemas/AsyncResponse_iepd/api/xml_schema/niem/xsd/niem-core.xsd
+++ b/schemas/AsyncResponse_iepd/api/xml_schema/niem/xsd/niem-core.xsd
@@ -47,7 +47,12 @@
   </xs:complexType>
   <xs:element name="MessageID" type="niem-xs:string" nillable="true">
     <xs:annotation>
-      <xs:documentation>A message identifier associated with an email or message content.</xs:documentation>
+      <xs:documentation>The original messageID that was set by the originator of the message.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TransactionID" type="niem-xs:string" nillable="true">
+    <xs:annotation>
+      <xs:documentation>The original transactionID that was set by the originator of the message.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="OrganizationName" type="nc:TextType" nillable="true">

--- a/schemas/AsyncResponse_iepd/examples/Complete_AsyncResponse.xml
+++ b/schemas/AsyncResponse_iepd/examples/Complete_AsyncResponse.xml
@@ -10,8 +10,10 @@
 		<SystemEventDateTime>2001-12-17T09:30:47Z</SystemEventDateTime>
 		<!--  Class: AsynchronousResponse, Attribute: responseDescription  -->
 		<SystemEventDescriptionText>String</SystemEventDescriptionText>
-		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<!--  Class: AsynchronousResponse, Attribute: messageID  -->
 		<nc:MessageID>String</nc:MessageID>
+		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<nc:TransactionID>String</nc:TransactionID>
 		<!--  Class: AsynchronousResponse, Attribute: transactionStatusCode  -->
 		<MessageStatusCode>Success</MessageStatusCode>
 		<!--  Class: AsynchronousResponse, Association: SchemaError  -->

--- a/schemas/AsyncResponse_iepd/examples/ContentError_AsyncResponse.xml
+++ b/schemas/AsyncResponse_iepd/examples/ContentError_AsyncResponse.xml
@@ -18,8 +18,10 @@ xsi:schemaLocation="http://mcp.com/nola/v/1.0/ ../api/xml_schema/Asynchronous_NO
 		<SystemEventDateTime>2017-01-07T13:47:42</SystemEventDateTime>
 		<!--  Class: AsynchronousResponse, Attribute: responseDescription  -->
 		<SystemEventDescriptionText>Failed to put message into staging system.</SystemEventDescriptionText>
-		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<!--  Class: AsynchronousResponse, Attribute: messageID  -->
 		<nc:MessageID>a8fa7290-b4d7-4c9f-8734-3a718d086299</nc:MessageID>
+		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<nc:TransactionID>b9ab8301-c5e8-5d0a-9845-4b829e17100</nc:TransactionID>
 		<!--  Class: AsynchronousResponse, Attribute: transactionStatusCode  -->
 		<MessageStatusCode>InvalidSchema</MessageStatusCode>
 		<!--  Class: AsynchronousResponse, Association: SchemaError  -->

--- a/schemas/AsyncResponse_iepd/examples/EndpointError_AsyncResponse.xml
+++ b/schemas/AsyncResponse_iepd/examples/EndpointError_AsyncResponse.xml
@@ -18,8 +18,10 @@ xsi:schemaLocation="http://mcp.com/nola/v/1.0/ ../api/xml_schema/Asynchronous_NO
 		<SystemEventDateTime>2017-01-07T13:47:42</SystemEventDateTime>
 		<!--  Class: AsynchronousResponse, Attribute: responseDescription  -->
 		<SystemEventDescriptionText>Failed to put message into staging system.</SystemEventDescriptionText>
-		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<!--  Class: AsynchronousResponse, Attribute: messageID  -->
 		<nc:MessageID>a8fa7290-b4d7-4c9f-8734-3a718d086299</nc:MessageID>
+		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<nc:TransactionID>b9ab8301-c5e8-5d0a-9845-4b829e17100</nc:TransactionID>
 		<!--  Class: AsynchronousResponse, Attribute: transactionStatusCode  -->
 		<MessageStatusCode>SystemError</MessageStatusCode>
 		<!--  Class: AsynchronousResponse, Association: ProcessingError  -->

--- a/schemas/AsyncResponse_iepd/examples/FinalAccept_AsyncResponse.xml
+++ b/schemas/AsyncResponse_iepd/examples/FinalAccept_AsyncResponse.xml
@@ -12,6 +12,8 @@
 		<SystemEventDescriptionText>Approved</SystemEventDescriptionText>
 		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
 		<nc:MessageID>a8fa7290-b4d7-4c9f-8734-3a718d086299</nc:MessageID>
+		<!--  Class: AsynchronousResponse, Attribute: messageID  -->
+		<nc:TransactionID>b9ab8301-c5e8-5d0a-9845-4b829e17100</nc:TransactionID>
 		<!--  Class: AsynchronousResponse, Attribute: transactionStatusCode  -->
 		<MessageStatusCode>Success</MessageStatusCode>
 		<nola-ext:MessageStatusAugmentation>

--- a/schemas/AsyncResponse_iepd/examples/Intermediate_AsyncResponse.xml
+++ b/schemas/AsyncResponse_iepd/examples/Intermediate_AsyncResponse.xml
@@ -11,8 +11,10 @@
 		<SystemEventDateTime>2020-03-07T13:47:42</SystemEventDateTime>
 		<!--  Class: AsynchronousResponse, Attribute: responseDescription  -->
 		<SystemEventDescriptionText>Received</SystemEventDescriptionText>
-		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<!--  Class: AsynchronousResponse, Attribute: messageID  -->
 		<nc:MessageID>a8fa7290-b4d7-4c9f-8734-3a718d086299</nc:MessageID>
+		<!--  Class: AsynchronousResponse, Attribute: transactionID  -->
+		<nc:TransactionID>b9ab8301-c5e8-5d0a-9845-4b829e17100</nc:TransactionID>
 		<!--  Class: AsynchronousResponse, Attribute: transactionStatusCode  -->
 		<MessageStatusCode>Success</MessageStatusCode>
 		<!--  Class: AsynchronousResponse, Association: ProcessingError  -->


### PR DESCRIPTION
We want users to be able to add not just the original messageID but also the transactionID (optional).